### PR TITLE
Change the name of the VsCode app to IDx Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Code - OSS",
+	"name": "IDx Code",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},

--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
-	"nameShort": "Code - OSS",
-	"nameLong": "Code - OSS",
-	"applicationName": "code-oss",
+	"nameShort": "IDx Code",
+	"nameLong": "IDx Code",
+	"applicationName": "idx-code",
 	"dataFolderName": ".vscode-oss",
 	"win32MutexName": "vscodeoss",
 	"licenseName": "MIT",

--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
-Name=@@NAME_LONG@@
+Name=IDx Code
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
 Exec=@@EXEC@@ %F
 Icon=@@ICON@@
 Type=Application
 StartupNotify=false
-StartupWMClass=@@NAME_SHORT@@
+StartupWMClass=IDx Code
 Categories=TextEditor;Development;IDE;
 MimeType=application/x-@@NAME@@-workspace;
 Actions=new-empty-window;

--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -1,4 +1,4 @@
-Package: @@NAME@@
+Package: idx-code
 Version: @@VERSION@@
 Section: devel
 Depends: @@DEPENDS@@
@@ -8,9 +8,9 @@ Architecture: @@ARCHITECTURE@@
 Maintainer: Microsoft Corporation <vscode-linux@microsoft.com>
 Homepage: https://code.visualstudio.com/
 Installed-Size: @@INSTALLEDSIZE@@
-Provides: visual-studio-@@NAME@@
-Conflicts: visual-studio-@@NAME@@
-Replaces: visual-studio-@@NAME@@
+Provides: visual-studio-idx-code
+Conflicts: visual-studio-idx-code
+Replaces: visual-studio-idx-code
 Description: Code editing. Redefined.
  Visual Studio Code is a new choice of tool that combines the simplicity of
  a code editor with what developers need for the core edit-build-debug cycle.

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -4,13 +4,13 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 # Symlink bin command to /usr/bin
-rm -f /usr/bin/@@NAME@@
-ln -s /usr/share/@@NAME@@/bin/@@NAME@@ /usr/bin/@@NAME@@
+rm -f /usr/bin/idx-code
+ln -s /usr/share/idx-code/bin/idx-code /usr/bin/idx-code
 
 # Register code in the alternatives system
 # Priority of 0 should never make code the default editor in auto mode as most
 # developers would prefer a terminal editor as the default.
-update-alternatives --install /usr/bin/editor editor /usr/bin/@@NAME@@ 0
+update-alternatives --install /usr/bin/editor editor /usr/bin/idx-code 0
 
 # Install the desktop entry
 if hash update-desktop-database 2>/dev/null; then
@@ -22,9 +22,9 @@ if hash update-mime-database 2>/dev/null; then
 	update-mime-database /usr/share/mime
 fi
 
-if [ "@@NAME@@" != "code-oss" ]; then
+if [ "idx-code" != "code-oss" ]; then
 	# Remove the legacy bin command if this is the stable build
-	if [ "@@NAME@@" = "code" ]; then
+	if [ "idx-code" = "code" ]; then
 		rm -f /usr/local/bin/code
 	fi
 
@@ -39,7 +39,7 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	RET=true
 	if [ -e '/usr/share/debconf/confmodule' ]; then
 		. /usr/share/debconf/confmodule
-		db_get @@NAME@@/add-microsoft-repo || true
+		db_get idx-code/add-microsoft-repo || true
 	fi
 
 	# Determine whether to install the repository source list
@@ -69,10 +69,10 @@ if [ "@@NAME@@" != "code-oss" ]; then
 
 	if [ "$WRITE_SOURCE" -eq "1" ] && [ -e '/usr/share/debconf/confmodule' ]; then
 		# Ask the user whether to actually write the source list
-		db_input high @@NAME@@/add-microsoft-repo || true
+		db_input high idx-code/add-microsoft-repo || true
 		db_go || true
 
-		db_get @@NAME@@/add-microsoft-repo
+		db_get idx-code/add-microsoft-repo
 		if [ "$RET" = false ]; then
 			WRITE_SOURCE=0
 		fi

--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-rm -f /usr/bin/@@NAME@@
+rm -f /usr/bin/idx-code
 
 # Uninstall the desktop entry
 if hash update-desktop-database 2>/dev/null; then
@@ -18,7 +18,7 @@ fi
 RET=true
 if [ -e '/usr/share/debconf/confmodule' ]; then
 	. /usr/share/debconf/confmodule
-	db_get @@NAME@@/add-microsoft-repo || true
+	db_get idx-code/add-microsoft-repo || true
 fi
 if [ "$RET" = "true" ]; then
 	eval $(apt-config shell APT_SOURCE_PARTS Dir::Etc::sourceparts/d)

--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -1,4 +1,4 @@
-Name:     @@NAME@@
+Name:     idx-code
 Version:  @@VERSION@@
 Release:  @@RELEASE@@.el8
 Summary:  Code editing. Redefined.


### PR DESCRIPTION
Change the name of the VsCode app to "IDX Code".

* **product.json**: Change `nameShort` to "IDx Code", `nameLong` to "IDx Code", and `applicationName` to "idx-code".
* **.devcontainer/devcontainer.json**: Change `name` to "IDx Code".
* **resources/linux/code.desktop**: Change `Name` to "IDx Code" and `StartupWMClass` to "IDx Code".
* **resources/linux/debian/control.template**: Change `Package` to "idx-code", `Provides` to "visual-studio-idx-code", `Conflicts` to "visual-studio-idx-code", and `Replaces` to "visual-studio-idx-code".
* **resources/linux/debian/postinst.template**: Change `@@NAME@@` to "idx-code".
* **resources/linux/debian/postrm.template**: Change `@@NAME@@` to "idx-code".
* **resources/linux/rpm/code.spec.template**: Change `Name` to "idx-code".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HomeDev68/IDX-Code?shareId=756c1e01-8f3c-4ced-a526-62b375d2923d).